### PR TITLE
Testnet Network Support

### DIFF
--- a/src/lnsocket.rs
+++ b/src/lnsocket.rs
@@ -52,7 +52,7 @@ impl LNSocket {
     /// Resolves the given `addr`, establishes a TCP connection, and performs act1/act2/act3
     /// handshake using `our_key` and the peer’s public key.
     ///
-    /// Does **not** send or expect an `init` message.
+    /// Does **not** send or expect an `init` message.  
     /// Use [`LNSocket::connect_and_init`] if you want handshake + `init` exchange.
     pub async fn connect(
         our_key: SecretKey,


### PR DESCRIPTION
This PR makes a small change where for the INIT message we echo back the networks that the node has sent to us in their INIT message. This means that lnsocket can be used with testnets for development.

To test the change you can run [Polar](https://lightningpolar.com/), spin up a CLN node and then connect to it on the "P2P External" address.