### PR TITLE
Add TOR Support for .onion Addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +229,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-socks",
  "tracing",
 ]
 
@@ -248,6 +279,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -398,6 +435,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +479,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@ serde = { version = "1", features = ["derive"] }
 #serde_derive = "1"
 serde_json = "1"
 hex = "0.4.3"
+tokio-socks = "0.5.2"
 
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 use crate::ln::msgs::{DecodeError, LightningError};
+use crate::socket_addr::SocketAddressParseError;
 use serde::Deserialize;
 use std::fmt;
 use std::io;
-use std::net::AddrParseError;
 
 /// Errors surfaced by this crate.
 ///
@@ -20,8 +20,9 @@ pub enum Error {
     Json,
     Lightning(LightningError),
     Decode(DecodeError),
-    AddrParse(std::net::AddrParseError),
+    AddrParse(SocketAddressParseError),
     Rpc(RpcError),
+    ProxyConnection(String),
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -42,6 +43,7 @@ impl fmt::Display for Error {
             Error::Json => write!(f, "json error"),
             Error::AddrParse(err) => write!(f, "Address parse error: {err}"),
             Error::Rpc(err) => write!(f, "commando rpc error: {err:?}"),
+            Error::ProxyConnection(msg) => write!(f, "TOR connection error: {msg}"),
         }
     }
 }
@@ -70,8 +72,8 @@ impl From<LightningError> for Error {
     }
 }
 
-impl From<AddrParseError> for Error {
-    fn from(err: AddrParseError) -> Self {
+impl From<SocketAddressParseError> for Error {
+    fn from(err: SocketAddressParseError) -> Self {
         Self::AddrParse(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ mod crypto;
 pub mod error;
 pub mod ln;
 pub mod lnsocket;
+pub mod proxy;
 mod sign;
 mod socket_addr;
 mod util;
@@ -63,6 +64,7 @@ pub use bitcoin;
 pub use commando::{CallOpts, CommandoClient};
 pub use error::{Error, RpcError};
 pub use lnsocket::LNSocket;
+pub use proxy::TorConfig;
 
 mod prelude {
     #![allow(unused_imports)]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,0 +1,88 @@
+//! TOR support for onion address connections
+
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
+use tokio_socks::tcp::Socks5Stream;
+
+/// Default TOR proxy configuration (localhost:9050)
+pub struct TorConfig {
+    /// SOCKS5 proxy host (default "127.0.0.1" for local TOR)
+    pub host: String,
+    /// SOCKS5 proxy port (default 9050 for TOR)
+    pub port: u16,
+}
+
+impl Default for TorConfig {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".to_string(),
+            port: 9050,
+        }
+    }
+}
+
+impl TorConfig {
+    /// Create a new TorConfig with custom host and port
+    pub fn new(host: String, port: u16) -> Self {
+        Self { host, port }
+    }
+
+    /// Get the proxy address as a string
+    pub fn proxy_addr(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+/// A unified stream type that can be either direct TCP or TOR SOCKS5
+pub enum LnStream {
+    /// Direct TCP stream
+    Direct(TcpStream),
+    /// TOR SOCKS5 proxied stream
+    Tor(Socks5Stream<TcpStream>),
+}
+
+impl AsyncRead for LnStream {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            LnStream::Direct(stream) => std::pin::Pin::new(stream).poll_read(cx, buf),
+            LnStream::Tor(stream) => std::pin::Pin::new(stream).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for LnStream {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            LnStream::Direct(stream) => std::pin::Pin::new(stream).poll_write(cx, buf),
+            LnStream::Tor(stream) => std::pin::Pin::new(stream).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            LnStream::Direct(stream) => std::pin::Pin::new(stream).poll_flush(cx),
+            LnStream::Tor(stream) => std::pin::Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            LnStream::Direct(stream) => std::pin::Pin::new(stream).poll_shutdown(cx),
+            LnStream::Tor(stream) => std::pin::Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}


### PR DESCRIPTION
- Added TOR SOCKS5 proxy support for connecting to .onion addresses
- Introduced `TorConfig` struct for configurable proxy settings (defaults to 127.0.0.1:9050)
- Created `LnStream` enum to handle both direct TCP and proxied connections
- Added `connect_with_tor_config()` and `connect_and_init_with_tor_config()` methods
- Automatic detection of .onion addresses to route through TOR proxy
- Updated dependency: added `tokio-socks` for SOCKS5 support
- New public types: `TorConfig`
- Existing methods remain unchanged for backward compatibility